### PR TITLE
Fix relative path on zodbconn.uri

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -19,7 +19,7 @@ pyramid.includes =
     pyramid_webassets
     cornice
 
-zodbconn.uri = file://%(here)s/papaye.db?blobstorage_dir=packages
+zodbconn.uri = file://%(here)s/papaye.db?blobstorage_dir=%(here)s/packages
 jinja2.directories = papaye:templates
 
 papaye.proxy = true

--- a/production.ini
+++ b/production.ini
@@ -18,7 +18,7 @@ pyramid.includes =
     pyramid_webassets
     cornice
 
-zodbconn.uri = file://%(here)s/papaye.db?blobstorage_dir=packages
+zodbconn.uri = file://%(here)s/papaye.db?blobstorage_dir=%(here)s/packages
 jinja2.directories = papaye:templates
 
 papaye.proxy = true


### PR DESCRIPTION
"Permission denied" when you try to launch papaye outside the project directory (with systemd in my case :-))
